### PR TITLE
fix: promote trainer counters to an enabled mart with Badge_8 coverage

### DIFF
--- a/models/marts/_schema.yml
+++ b/models/marts/_schema.yml
@@ -227,6 +227,83 @@ models:
         - name: variant_description
           description: "Human-readable description of run variant including rival type"
 
+  - name: mart_trainer_counters
+    description: "Trainer difficulty + top 5 counter pokemon per opponent pokemon, with catch location/level for each counter. Consumed by the dbtPlaysPokemon agent planner (dbt_catalog.json 'trainer_counters'). Grain: one row per (run_name, game_stage, trainer_pkmn_id, counter_rank)."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [run_name, game_stage, trainer_pkmn_id, counter_rank]
+    columns:
+        - name: run_name
+          description: "Run variant identifier (e.g., Jolteon_NoPikachu_Ledges)"
+          tests:
+            - not_null
+        - name: rival_type
+          description: "Rival eeveelution for this run (Jolteon, Vaporeon, Flareon)"
+        - name: variant_description
+          description: "Human-readable description of run variant"
+        - name: game_stage
+          description: "Game progression stage (Badge_1 .. Badge_8, Elite 4, Rematches)"
+          tests:
+            - not_null
+            - accepted_values:
+                arguments:
+                  values: ['Badge_1', 'Badge_2', 'Badge_3', 'Badge_4', 'Badge_5', 'Badge_6', 'Badge_7', 'Badge_8', 'Elite 4', 'Rematches']
+        - name: trainer
+          description: "Name of the opposing trainer"
+          tests:
+            - not_null
+        - name: is_mini_boss
+          description: "Flag indicating if the trainer is a mini boss (1) or regular trainer (0)"
+        - name: difficulty_rank
+          description: "Trainer difficulty ranking within the stage (1 = hardest)"
+        - name: difficulty_rating
+          description: "Trainer difficulty classification"
+        - name: trainer_pkmn_id
+          description: "Unique identifier for trainer pokemon instance"
+          tests:
+            - not_null
+        - name: trainer_pokemon
+          description: "Trainer pokemon species name"
+        - name: trainer_pkmn_level
+          description: "Trainer pokemon level"
+        - name: counter_pokemon
+          description: "Player pokemon species recommended against this opponent"
+          tests:
+            - not_null
+        - name: counter_rank
+          description: "Counter ranking per opponent pokemon (1 = best, max 5)"
+          tests:
+            - not_null
+        - name: battle_score
+          description: "Calculated battle outcome score (0-1 scale, 1 = complete player advantage)"
+        - name: counter_move
+          description: "Best move for the counter pokemon in this matchup"
+        - name: counter_move_origin
+          description: "Source of the counter move (level-up, repurchasable-tm, single-use-tm)"
+        - name: requires_single_use_tm
+          description: "Whether the counter move requires a single-use TM (1) or not (0)"
+        - name: player_turns_to_ko
+          description: "Number of turns for the counter pokemon to KO the opponent"
+        - name: opponent_move
+          description: "Best move the opponent uses against our counter pokemon"
+        - name: opponent_turns_to_ko
+          description: "Number of turns for the opponent to KO our counter pokemon"
+        - name: catch_display_name
+          description: "Where to catch the counter pokemon (NULL if not wild-catchable at this stage, e.g. starters/trades/evolutions)"
+        - name: catch_level
+          description: "Level at which the counter pokemon can be caught"
+        - name: counter_evolution_note
+          description: "How to evolve the counter pokemon from its base form (NULL for base forms)"
+        - name: opponent_type1
+          description: "Trainer pokemon primary type"
+        - name: opponent_type2
+          description: "Trainer pokemon secondary type"
+        - name: counter_type1
+          description: "Counter pokemon primary type"
+        - name: counter_type2
+          description: "Counter pokemon secondary type"
+
   - name: mart_min_exp_squads
     description: "Minimum-EXP teams via cheapest-counter assignment. Assigns each opponent to its cheapest counter, ranks pokemon by coverage/cost efficiency, and computes EXP earned from trainer battles."
     columns:

--- a/models/marts/_semantic.yml
+++ b/models/marts/_semantic.yml
@@ -123,6 +123,63 @@ semantic_models:
         expr: avg_mini_boss_score
         agg: average
 
+  - name: trainer_counters
+    description: |
+      Top 5 counter pokemon per opponent trainer pokemon across run variants,
+      with trainer difficulty and catch location/level for each counter.
+    model: ref('mart_trainer_counters')
+    defaults:
+      agg_time_dimension: game_data_date
+
+    entities:
+      - name: counter_slot
+        type: primary
+        expr: "run_name || '|' || game_stage || '|' || trainer_pkmn_id || '|' || cast(counter_rank as varchar)"
+      - name: pokemon
+        type: foreign
+        expr: counter_pokemon
+      - name: game_stage
+        type: foreign
+        expr: game_stage
+      - name: trainer
+        type: foreign
+        expr: trainer
+
+    dimensions:
+      - name: game_data_date
+        type: time
+        expr: "cast('2024-01-01' as date)"
+        type_params:
+          time_granularity: day
+      - name: run_name
+        type: categorical
+      - name: rival_type
+        type: categorical
+      - name: game_stage_name
+        type: categorical
+        expr: game_stage
+      - name: trainer_name
+        type: categorical
+        expr: trainer
+      - name: counter_pokemon_name
+        type: categorical
+        expr: counter_pokemon
+      - name: difficulty_rating
+        type: categorical
+      - name: counter_rank
+        type: categorical
+        expr: cast(counter_rank as varchar)
+
+    measures:
+      - name: avg_counter_battle_score
+        description: "Average battle score of listed counters"
+        expr: battle_score
+        agg: average
+      - name: counter_count
+        description: "Number of counter rows"
+        expr: "1"
+        agg: sum
+
 metrics:
   - name: available_pokemon_by_stage
     type: simple

--- a/models/marts/mart_trainer_counters.sql
+++ b/models/marts/mart_trainer_counters.sql
@@ -1,0 +1,208 @@
+-- mart_trainer_counters: Trainer difficulty + top 5 counters per opponent pokemon,
+-- with where/what-level to catch each counter.
+-- Promoted from the deleted dash_trainer_counters (issue #14): the dbtPlaysPokemon
+-- agent's planner reads this via dbt_catalog.json "trainer_counters", so it must be
+-- an ENABLED mart that survives a clean rebuild (the dashboard layer is disabled).
+-- Grain: one row per (run_name, game_stage, trainer_pkmn_id, counter_rank)
+
+WITH run_variants AS (
+    {{ generate_run_variants(ref('mart_battle_outcomes')) }}
+),
+
+-- Best move per (player_pokemon, trainer_pkmn_id)
+best_moves AS (
+    SELECT
+        bo.game_stage,
+        bo.player_pkmn_id,
+        bo.player_pokemon,
+        bo.trainer,
+        bo.is_mini_boss,
+        bo.trainer_pkmn_id,
+        bo.trainer_pokemon,
+        bo.trainer_pkmn_level,
+        bo.player_pkmn_move,
+        bo.player_pkmn_move_origin,
+        bo.player_move_single_use_tm,
+        bo.player_attempts_to_ko,
+        bo.trainer_pkmn_move,
+        bo.trainer_attempts_to_ko,
+        bo.battle_score,
+        bo.player_victory
+    FROM {{ ref('mart_battle_outcomes') }} bo
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY bo.player_pkmn_id, bo.trainer_pkmn_id
+        ORDER BY bo.battle_score DESC
+    ) = 1
+),
+
+-- Trainer difficulty (same formula as mart_team_performance)
+trainer_difficulty AS (
+    SELECT
+        game_stage,
+        trainer,
+        is_mini_boss,
+        AVG(battle_score) AS avg_battle_score,
+        MIN(battle_score) AS min_battle_score,
+        COUNT(CASE WHEN battle_score >= 0.8 THEN 1 END) AS excellent_counters,
+        COUNT(CASE WHEN battle_score >= 0.6 THEN 1 END) AS good_counters,
+        COUNT(CASE WHEN player_move_single_use_tm = 1 AND battle_score >= 0.6 THEN 1 END) AS tm_dependent_solutions,
+        COUNT(CASE WHEN player_move_single_use_tm = 0 AND battle_score >= 0.6 THEN 1 END) AS natural_solutions
+    FROM best_moves
+    GROUP BY game_stage, trainer, is_mini_boss
+),
+
+difficulty_class AS (
+    SELECT
+        *,
+        {{ trainer_difficulty_rating() }} AS difficulty_rating,
+        {{ trainer_difficulty_score() }} AS difficulty_score
+    FROM trainer_difficulty
+),
+
+-- Rank trainers by difficulty per stage
+trainer_ranks AS (
+    SELECT
+        dc.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY dc.game_stage
+            ORDER BY dc.difficulty_score DESC, dc.avg_battle_score ASC
+        ) AS difficulty_rank
+    FROM difficulty_class dc
+),
+
+-- Rank counter pokemon per trainer_pkmn_id, keep top 5
+counter_ranks AS (
+    SELECT
+        bm.game_stage,
+        bm.trainer,
+        bm.is_mini_boss,
+        bm.trainer_pkmn_id,
+        bm.trainer_pokemon,
+        bm.trainer_pkmn_level,
+        bm.player_pokemon AS counter_pokemon,
+        bm.battle_score,
+        bm.player_pkmn_move AS counter_move,
+        bm.player_pkmn_move_origin AS counter_move_origin,
+        bm.player_move_single_use_tm AS requires_single_use_tm,
+        bm.player_attempts_to_ko AS player_turns_to_ko,
+        bm.trainer_pkmn_move AS opponent_move,
+        bm.trainer_attempts_to_ko AS opponent_turns_to_ko,
+        CASE WHEN {{ is_legendary('bm.player_pokemon') }}
+            THEN 1 ELSE 0
+        END AS is_legendary,
+        ROW_NUMBER() OVER (
+            PARTITION BY bm.trainer_pkmn_id
+            ORDER BY bm.battle_score DESC
+        ) AS counter_rank
+    FROM best_moves bm
+),
+
+top_counters AS (
+    SELECT * FROM counter_ranks WHERE counter_rank <= 5
+),
+
+-- Pokemon types
+pkmn_types AS (
+    SELECT pokemon, type1, type2
+    FROM {{ ref('stg_pkmn_stats') }}
+),
+
+{{ collapse_evolution_chains('top_counters', 'counter_pokemon', 'game_stage') }}
+
+-- Opponent types
+opponent_types AS (
+    SELECT pokemon, type1 AS opponent_type1, type2 AS opponent_type2
+    FROM {{ ref('stg_pkmn_stats') }}
+),
+
+-- Best catch location + level per (pokemon, game_stage)
+catch_locations AS (
+    SELECT
+        pa.pokemon,
+        pa.game_stage,
+        ml.display_name AS catch_display_name,
+        pa.encounter_level AS catch_level,
+        ROW_NUMBER() OVER (
+            PARTITION BY pa.pokemon, pa.game_stage
+            ORDER BY pa.earliest_route ASC, pa.encounter_level DESC NULLS LAST
+        ) AS loc_rank
+    FROM {{ ref('int_pokemon_availability') }} pa
+    LEFT JOIN {{ ref('stg_map_location_groups') }} mlg
+        ON mlg.game_route_map = pa.map
+    LEFT JOIN {{ ref('stg_map_locations') }} ml
+        ON ml.map = mlg.map_location
+    WHERE pa.availability_type = 'Catchable'
+        AND pa.encounter_level IS NOT NULL
+),
+
+best_catch AS (
+    SELECT * FROM catch_locations WHERE loc_rank = 1
+),
+
+-- Cross-join trainers with run variants, apply filters
+variant_trainers AS (
+    SELECT
+        rv.run_name,
+        rv.rival_type,
+        rv.keep_pikachu,
+        rv.no_legends,
+        rv.exclude_rival_patterns,
+        rv.exclude_trainers,
+        tr.game_stage,
+        tr.trainer,
+        tr.is_mini_boss,
+        tr.difficulty_rank,
+        tr.difficulty_rating,
+        {{ generate_variant_description('rv.rival_type', 'rv.keep_pikachu', 'rv.no_legends') }} AS variant_description
+    FROM trainer_ranks tr
+    INNER JOIN run_variants rv
+        ON rv.game_stage = tr.game_stage
+    WHERE NOT (tr.trainer LIKE rv.exclude_rival_patterns[1])
+      AND NOT (tr.trainer LIKE rv.exclude_rival_patterns[2])
+      AND NOT list_contains(rv.exclude_trainers, tr.trainer)
+)
+
+SELECT
+    vt.run_name,
+    vt.rival_type,
+    vt.variant_description,
+    vt.game_stage,
+    vt.trainer,
+    vt.is_mini_boss,
+    vt.difficulty_rank,
+    vt.difficulty_rating,
+    tc.trainer_pkmn_id,
+    tc.trainer_pokemon,
+    tc.trainer_pkmn_level,
+    tc.counter_pokemon,
+    tc.counter_rank,
+    tc.battle_score,
+    tc.counter_move,
+    tc.counter_move_origin,
+    tc.requires_single_use_tm,
+    tc.player_turns_to_ko,
+    tc.opponent_move,
+    tc.opponent_turns_to_ko,
+    bc.catch_display_name,
+    bc.catch_level,
+    en.evolution_note AS counter_evolution_note,
+    ot.opponent_type1,
+    ot.opponent_type2,
+    ct.type1 AS counter_type1,
+    ct.type2 AS counter_type2
+FROM variant_trainers vt
+INNER JOIN top_counters_deduped tc
+    ON tc.game_stage = vt.game_stage
+    AND tc.trainer = vt.trainer
+LEFT JOIN best_catch bc
+    ON bc.pokemon = tc.counter_pokemon
+    AND bc.game_stage = vt.game_stage
+LEFT JOIN _evo_notes en
+    ON en.pokemon = tc.counter_pokemon
+LEFT JOIN opponent_types ot
+    ON ot.pokemon = tc.trainer_pokemon
+LEFT JOIN pkmn_types ct
+    ON ct.pokemon = tc.counter_pokemon
+-- Filter counter pokemon by legendary/pikachu rules per variant
+WHERE (vt.no_legends = 0 OR tc.is_legendary = 0)
+ORDER BY vt.run_name, vt.game_stage, vt.difficulty_rank, tc.trainer_pkmn_id, tc.counter_rank


### PR DESCRIPTION
## Summary

Fixes #14 — the agent's planner `counters` view reads `dbt_catalog.json` `trainer_counters`, which pointed at `dash_trainer_counters`: a **deleted model** in the disabled dashboard layer. It only resolved against a stale table frozen in the committed DuckDB file (which also had **no Badge_8 stage**) and disappears entirely on a clean rebuild.

## Changes

- **New `models/marts/mart_trainer_counters.sql`** (enabled): trainer difficulty + top-5 counters per opponent pokemon, promoted from the deleted dashboard model
  - Based on `dash_team_counters`, dropping the `dash_team_roster` join (an enabled mart can't depend on the disabled dashboard layer)
  - Adds `catch_display_name` / `catch_level` via `int_pokemon_availability` + map location staging (best location per pokemon/stage — same pattern as `dash_team_builder`)
  - Output matches the 27 columns the agent's catalog documents
- **`marts/_schema.yml`**: grain uniqueness on `(run_name, game_stage, trainer_pkmn_id, counter_rank)`, `not_null` on keys, `accepted_values` on the full `game_stage` domain (`Badge_1`..`Badge_8`, `Elite 4`, `Rematches`)
- **`marts/_semantic.yml`**: `trainer_counters` semantic model

## Verification

- [x] `dbt build --select +mart_trainer_counters` — 74 PASS, 0 errors (1 pre-existing warn on `assert_team_beats_all_opponents`, unrelated)
- [x] Badge_8 present: 1,416 rows (stale table had none); all 10 stages produce rows
- [x] `catch_display_name`/`catch_level` populated for wild-catchable counters (NULL for starters/trades/evolved-only forms, documented)
- [x] Success criterion 9 holds: marts 10 files < intermediate 13

## Follow-up (out of scope)

- Cross-repo: re-point `dbt_catalog.json` `trainer_counters` from `dash_trainer_counters` to `mart_trainer_counters` and drop the Badge_8 workaround from `strategy_notes` — tracked in dbtPlaysPokemon.
