### PR TITLE
test: add tests to load-bearing models + fix rematch roster duplication (closes #16)

### DIFF
--- a/models/intermediate/_schema.yml
+++ b/models/intermediate/_schema.yml
@@ -258,3 +258,41 @@ models:
           description: "Area type of destination map"
         - name: navigation_instruction
           description: "Human-readable instruction for using this connection"
+
+  - name: int_map_pathfinding
+    description: "Walkable tile adjacency graph per map. For each walkable tile, lists which neighboring tiles can be reached and in which direction, accounting for walls (blocked), ledges (one-way), and grass (encounter risk). Grain: one row per (map_name, from_x, from_y, direction)."
+    columns:
+        - name: map_name
+          description: "Memory reader enum name for the map, part of the composite grain"
+        - name: from_x
+          description: "X coordinate of the source tile, part of the composite grain"
+        - name: from_y
+          description: "Y coordinate of the source tile, part of the composite grain"
+        - name: from_tile_type
+          description: "Terrain type of the source tile"
+        - name: to_x
+          description: "X coordinate of the destination tile"
+        - name: to_y
+          description: "Y coordinate of the destination tile"
+        - name: to_tile_type
+          description: "Terrain type of the destination tile"
+        - name: direction
+          description: "Movement direction from source to destination (up, down, left, right), part of the composite grain"
+        - name: is_passable
+          description: "Whether this edge can be traversed (always TRUE in output; impassable ledge entries are filtered out)"
+        - name: has_encounter_risk
+          description: "Whether the destination tile is grass (wild encounter risk)"
+
+  - name: int_map_components
+    description: "Weakly-connected components of each map's walkable graph. Labels every walkable tile with a subregion_id so consumers can tell an intentional split map (e.g. ROUTE_2's north/south halves) from a genuine data hole. Components are undirected: one-way ledge drops are treated as ordinary connectivity."
+    columns:
+        - name: map_name
+          description: "Memory reader enum name for the map"
+        - name: x
+          description: "Tile X coordinate"
+        - name: y
+          description: "Tile Y coordinate"
+        - name: subregion_id
+          description: "0-based component label, stable per map (components ordered by their smallest tile)"
+        - name: component_size
+          description: "Number of walkable tiles in this tile's component"

--- a/models/intermediate/int_opponent_pokemon.sql
+++ b/models/intermediate/int_opponent_pokemon.sql
@@ -67,6 +67,12 @@ WITH all_trainer_moves AS (
         move,
         move_number
     FROM {{ ref('stg_trainers_postgame') }}
+    -- Gym leader rematches appear in BOTH stg_trainers_gym_leaders and
+    -- stg_trainers_postgame with identical levels/moves. Keep the gym_leaders
+    -- copy (correct species, drives the is_mini_boss flag) and drop the
+    -- postgame duplicate, else colliding pkmn_ids fan out downstream and
+    -- break mart_battle_outcomes.matchup_id uniqueness.
+    WHERE trainer NOT IN (SELECT trainer FROM {{ ref('stg_trainers_gym_leaders') }})
 ),
 
 trainer_roster AS (

--- a/models/marts/_schema.yml
+++ b/models/marts/_schema.yml
@@ -32,6 +32,9 @@ models:
     columns:
         - name: matchup_id
           description: "Unique identifier for each battle matchup"
+          tests:
+            - unique
+            - not_null
         - name: game_stage
           description: "Game progression stage (Badge_1, Badge_2, etc.)"
         - name: player

--- a/models/staging/_schema.yml
+++ b/models/staging/_schema.yml
@@ -477,6 +477,32 @@ models:
         - name: water_rate
           description: "Water tile encounter rate byte (0-255); P(encounter/step) = water_rate/256. Null for maps with no surf/fishing encounters."
 
+  - name: stg_nav_map_tiles
+    description: "Per-tile collision and terrain data for navigable maps -- the collision source of truth for pathfinding. One row per (map_name, x, y). Regenerated from the ROM disassembly by scripts/extract_map_tiles.py."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [map_name, x, y]
+    columns:
+        - name: map_name
+          description: "Memory reader enum name for the map (e.g. PLAYERS_HOUSE_1F), part of the composite primary key"
+          tests:
+            - not_null
+        - name: x
+          description: "Tile X coordinate (matches memory reader coordinates), part of the composite primary key"
+          tests:
+            - not_null
+        - name: y
+          description: "Tile Y coordinate (matches memory reader coordinates), part of the composite primary key"
+          tests:
+            - not_null
+        - name: tile_type
+          description: "Terrain type of the tile (e.g. path, grass, water, ledge, wall)"
+        - name: walkable
+          description: "Whether the player can stand on this tile"
+        - name: ledge_direction
+          description: "For ledge tiles, the direction the ledge can be hopped (null otherwise)"
+
   - name: stg_nav_map_metadata
     description: "Map properties for navigation - dimensions, type, and parent area for maps from Pallet Town through Pewter City"
     columns:


### PR DESCRIPTION
## Summary

Closes #16.

- **`stg_nav_map_tiles`** (94,908 rows, collision source of truth): new schema entry with `dbt_utils.unique_combination_of_columns` on `(map_name, x, y)` + `not_null` on the key columns -- per staging convention (PK tests only). Guards future `extract_map_tiles.py` seed regenerations.
- **`mart_battle_outcomes.matchup_id`**: `unique` + `not_null`.
- **Docs-only schema entries** for `int_map_pathfinding` (grain: `map_name, from_x, from_y, direction`) and `int_map_components` -- intermediate keeps no tests, per convention.
- `int_encounter_lookup`'s schema entry is intentionally **not** added here: it lands in PR #20 (issue #13) and adding it would conflict.

## Bug found by the new test

The `unique` test on `matchup_id` failed immediately with **819 duplicate rows** -- proving the issue's point. Root cause: gym leader rematches (Brock/Misty/Lt. Surge/Sabrina/Koga/Blaine) exist in **both** `stg_trainers_gym_leaders` and `stg_trainers_postgame` with identical levels/moves. `int_opponent_pokemon` unioned both, giving each rematch trainer a 12-pokemon roster; colliding `pkmn_id`s (e.g. `Blaine_Rematch_Rapidash_1`) fanned out into identical duplicate matchup rows.

Fix: the postgame branch now excludes trainers already present in `stg_trainers_gym_leaders`. The gym_leaders copy wins because it has the correct species (the postgame copy lists an `Exeggutor` carrying Ninetales' moves on Blaine's fire team) and drives the `is_mini_boss` flag.

## Test plan

- [x] `dbt build` -- 174 PASS, 0 errors
- [x] `unique_mart_battle_outcomes_matchup_id` passes after the dedupe fix (fails with 819/556 dupes without it)
- [x] All rematch trainers back to 6-pokemon rosters
- [x] Pre-existing warn-severity `assert_team_beats_all_opponents` unaffected by this change: uncovered opponents are Misty's Starmie, Surge's Raichu (by design -- damage-race scoring), Oak's legendaries. Its count wobbles run-to-run (84/105/119) from nondeterministic tie-breaking in team selection, on main as well as this branch.

## Follow-ups (out of scope, worth issues)

- `Erica_Rematch` (gym_leaders seed) vs `Erika_Rematch` (postgame seed): same leader under two spellings, so both rosters survive the dedupe and the player "faces" her twice.
- Nondeterministic tie-breaking in `mart_battle_outcomes` top-4 move selection / team ranking makes build outputs non-reproducible run-to-run.
