### PR TITLE
fix: stale DuckDB schemas masking renamed/deleted models (issue #15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ When working on this dbt project, use these skills from the dbt plugin:
 - `.venv/Scripts/dbt test` -- run data quality tests
 - `.venv/Scripts/dbt run --select <model_name>` -- run a specific model
 - `.venv/Scripts/dbt compile` -- compile SQL without running
+- `.venv/Scripts/dbt run-operation check_orphan_relations` -- fail if the database holds tables not in the manifest (stale-schema guard)
 
 ## Memory Between Iterations
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -41,6 +41,18 @@ and split the catch semantic view into its own `semantic/` folder.
   `assert_single_use_tms_unique` pass. `assert_team_beats_all_opponents` WARNs (75 rows) —
   pre-existing, `severity='warn'`, unrelated to the move.
 
+## 2026-07-04 — Stale-schema fix (issue #15)
+
+- Root cause: `data/create_database.py` used a cwd-relative db path, so "rebuilds" run from
+  the repo root created/deleted a db in the **root** while dbt kept writing to
+  `data/pkmn_yellow_legacy.db` — stale schemas (`optimisation.*`, old `main.*`, pre-rename
+  `intermediate.*`) survived every rebuild. Path is now anchored to the script's directory.
+- New guard: `dbt run-operation check_orphan_relations` diffs `information_schema.tables`
+  against the manifest (models + seeds) and fails listing any orphans. Run it after
+  renaming/deleting models. Excludes `dbt_test__audit` (dbt's store_failures schema).
+- Verified: check flagged 52 orphans on the stale db; after clean rebuild
+  (create_database.py → seed → build) it passes with 85 relations.
+
 ### Notes / gotchas
 - The venv lives at `.venv/Scripts/` (CLAUDE.md's `env/Scripts/` reference is stale).
 - The 3 `dash_*` models are disabled via `+enabled: false` in `dbt_project.yml`, so they do

--- a/data/create_database.py
+++ b/data/create_database.py
@@ -24,8 +24,9 @@ def create_database(db_path):
     except Exception as e:
         print(f"Failed to create database: {e}")
 
-# Specify the path to the database (relative to current working directory)
-db_path = 'pkmn_yellow_legacy.db'
+# Anchor to this script's directory so the db lands in data/ regardless of cwd
+# (matches profiles.yml path 'data/pkmn_yellow_legacy.db'; issue #15)
+db_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pkmn_yellow_legacy.db')
 
 # Create the database
 create_database(db_path)

--- a/macros/check_orphan_relations.sql
+++ b/macros/check_orphan_relations.sql
@@ -1,0 +1,35 @@
+{% macro check_orphan_relations() %}
+{#
+    Fails if the warehouse contains tables/views that are not in the current
+    dbt manifest (models + seeds). Guards against stale schemas silently
+    masking renamed/deleted models (issue #15).
+
+    Usage: dbt run-operation check_orphan_relations
+#}
+    {% set expected = [] %}
+    {% for node in graph.nodes.values() if node.resource_type in ('model', 'seed') %}
+        {% do expected.append((node.schema ~ '.' ~ (node.alias or node.name)) | lower) %}
+    {% endfor %}
+
+    {% set actual = run_query(
+        "select lower(table_schema) || '.' || lower(table_name) as rel
+         from information_schema.tables
+         where table_schema not in ('information_schema', 'pg_catalog', 'dbt_test__audit')"
+    ) %}
+
+    {% set orphans = [] %}
+    {% for row in actual.rows %}
+        {% if row['rel'] not in expected %}
+            {% do orphans.append(row['rel']) %}
+        {% endif %}
+    {% endfor %}
+
+    {% if orphans %}
+        {{ exceptions.raise_compiler_error(
+            'Found ' ~ orphans | length ~ ' orphan relation(s) not in the manifest — rebuild the database cleanly (data/create_database.py -> dbt seed -> dbt build): '
+            ~ orphans | join(', ')
+        ) }}
+    {% else %}
+        {{ log('check_orphan_relations: OK — all warehouse relations match the manifest (' ~ expected | length ~ ' expected).', info=true) }}
+    {% endif %}
+{% endmacro %}


### PR DESCRIPTION
Closes #15

## Root cause
`data/create_database.py` used a cwd-relative path (`'pkmn_yellow_legacy.db'`), while dbt's profile writes to `data/pkmn_yellow_legacy.db`. Run from the repo root (as documented in CLAUDE.md), every "rebuild" created/deleted a db in the **root** and never wiped the real one — so `optimisation.*`, old `main.*` copies, and pre-rename `intermediate.*` tables survived indefinitely and silently masked renamed/deleted models (e.g. `dash_trainer_counters`).

## Changes
- **`data/create_database.py`** — db path anchored to the script's directory, so it always targets `data/pkmn_yellow_legacy.db` regardless of cwd
- **`macros/check_orphan_relations.sql`** — new `dbt run-operation check_orphan_relations`: diffs `information_schema.tables` against the manifest (models + seeds) and raises with the orphan list; excludes `dbt_test__audit` (dbt's store_failures schema)
- **CLAUDE.md / PROGRESS.md** — documented the command and the learning

## Test plan
- [x] Check run against the stale db → **fails with 52 orphans**, exactly the relations named in the issue (`optimisation.*`, `main.*` copies, pre-rename `intermediate.*`)
- [x] Clean rebuild: `create_database.py` → `dbt seed` → `dbt build` → PASS=168, ERROR=0 (only pre-existing `assert_team_beats_all_opponents` warn)
- [x] Check re-run against the clean db → **passes**, 85 relations all matching the manifest
